### PR TITLE
Breaking: enforce flow pragma in files that need it

### DIFF
--- a/config/rules/flowtype.js
+++ b/config/rules/flowtype.js
@@ -5,5 +5,7 @@ module.exports = {
     'flowtype',
   ],
 
-  'rules': {},
+  'rules': {
+    'flowtype/no-types-missing-file-annotation': 'error',
+  },
 };


### PR DESCRIPTION
Enables the `flowtype/no-types-missing-file-annotation` rule, which reports files that are using type annotations but are missing a `// @flow` pragma at the top of the file.

See: https://github.com/gajus/eslint-plugin-flowtype#no-types-missing-file-annotation