### PR TITLE
Add disallow-default-import-and-module-name-mismatch rule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 *.log
 npm-debug.log*
+.vscode

--- a/config/rules/custom.js
+++ b/config/rules/custom.js
@@ -1,5 +1,6 @@
 module.exports = {
   rules: {
+    '@zapier/zapier/disallow-default-import-and-module-name-mismatch': 'warn',
     '@zapier/zapier/disallow-lodash-get-dot-notation': 'error',
   },
 };

--- a/custom-rules/disallow-default-import-and-module-name-mismatch.js
+++ b/custom-rules/disallow-default-import-and-module-name-mismatch.js
@@ -1,0 +1,28 @@
+module.exports = {
+meta: {
+  docs: {
+    description:
+      'disallow to use a different identifier than the module name.',
+  },
+},
+
+create(context) {
+  return {
+    ImportDeclaration(node) {
+      const [ specifier ] = node.specifiers;
+      const { value } = node.source;
+
+      if (specifier.type !== 'ImportDefaultSpecifier') return;
+      if (!value.startsWith('app/')) return;
+
+      if (specifier.local.name !== value.slice(value.lastIndexOf("/") + 1)) {
+        context.report({
+          node,
+          message:
+            'Default import identifier should be the same as the module name.'
+        });
+      }
+    }
+  }
+},
+};

--- a/custom-rules/disallow-default-import-and-module-name-mismatch.js
+++ b/custom-rules/disallow-default-import-and-module-name-mismatch.js
@@ -1,3 +1,5 @@
+const IGNORED_MODULES = /-|\.scss|\.graphql/;
+
 module.exports = {
 meta: {
   docs: {
@@ -10,16 +12,24 @@ create(context) {
   return {
     ImportDeclaration(node) {
       const [ specifier ] = node.specifiers;
+      if (!specifier) return;
+
       const { value } = node.source;
 
       if (specifier.type !== 'ImportDefaultSpecifier') return;
       if (!value.startsWith('app/')) return;
 
-      if (specifier.local.name !== value.slice(value.lastIndexOf("/") + 1)) {
+      const moduleName = value.slice(value.lastIndexOf("/") + 1)
+
+      if (IGNORED_MODULES.test(moduleName)) return
+
+      const { name } = specifier.local
+
+      if (name !== moduleName) {
         context.report({
           node,
           message:
-            'Default import identifier should be the same as the module name.'
+            `Default import "${name}" should be the same as the module name "${moduleName}".`
         });
       }
     }

--- a/custom-rules/disallow-default-import-and-module-name-mismatch.js
+++ b/custom-rules/disallow-default-import-and-module-name-mismatch.js
@@ -19,17 +19,17 @@ create(context) {
       if (specifier.type !== 'ImportDefaultSpecifier') return;
       if (!value.startsWith('app/')) return;
 
-      const moduleName = value.slice(value.lastIndexOf("/") + 1)
+      const moduleName = value.slice(value.lastIndexOf("/") + 1);
 
-      if (IGNORED_MODULES.test(moduleName)) return
+      if (IGNORED_MODULES.test(moduleName)) return;
 
-      const { name } = specifier.local
+      const { name } = specifier.local;
 
       if (name !== moduleName) {
         context.report({
           node,
           message:
-            `Default import "${name}" should be the same as the module name "${moduleName}".`
+            `Default import "${name}" should be the same as the module name "${moduleName}".`,
         });
       }
     }

--- a/custom-rules/disallow-default-import-and-module-name-mismatch.js
+++ b/custom-rules/disallow-default-import-and-module-name-mismatch.js
@@ -1,4 +1,4 @@
-const IGNORED_MODULES = /-|\.scss|\.graphql/;
+const IMPORTS_WHITELIST = /^app\/(?!graphql|legacy|.scss).*/;
 
 module.exports = {
 meta: {
@@ -17,12 +17,9 @@ create(context) {
       const { value } = node.source;
 
       if (specifier.type !== 'ImportDefaultSpecifier') return;
-      if (!value.startsWith('app/')) return;
+      if (!IMPORTS_WHITELIST.test(value)) return
 
       const moduleName = value.slice(value.lastIndexOf("/") + 1);
-
-      if (IGNORED_MODULES.test(moduleName)) return;
-
       const { name } = specifier.local;
 
       if (name !== moduleName) {

--- a/custom-rules/disallow-default-import-and-module-name-mismatch.js
+++ b/custom-rules/disallow-default-import-and-module-name-mismatch.js
@@ -1,4 +1,4 @@
-const IMPORTS_WHITELIST = /^app\/(?!graphql|legacy).*(?!.scss)/;
+const IMPORTS_BLACKLIST = /^app\/(?:graphql|legacy)|.scss/;
   
 const getRegularImportVariants = value =>
   [value.slice(value.lastIndexOf("/") + 1)];
@@ -13,10 +13,17 @@ const getComponentImportVariants = value =>
       return variants
     }, []);
 
-const getImportVariants = value =>
-  value.includes('components')
+const getImportVariants = value => {
+  value =
+    value[0].toUpperCase() +
+    value
+      .slice(1)
+      .replace(/-([a-z])/g, capture => capture[1].toUpperCase());
+  
+  return value.includes('components')
     ? getComponentImportVariants(value)
     : getRegularImportVariants(value);
+}
 
 module.exports = {
   meta: {
@@ -35,7 +42,7 @@ module.exports = {
         const { value } = node.source;
 
         if (specifier.type !== 'ImportDefaultSpecifier') return;
-        if (!IMPORTS_WHITELIST.test(value)) return;
+        if (!value.startsWith('app/') || IMPORTS_BLACKLIST.test(value)) return;
 
         const importVariants = getImportVariants(value);
         const { name } = specifier.local;

--- a/custom-rules/disallow-default-import-and-module-name-mismatch.js
+++ b/custom-rules/disallow-default-import-and-module-name-mismatch.js
@@ -16,38 +16,38 @@ const getComponentImportVariants = value =>
 const getImportVariants = value =>
   value.includes('components')
     ? getComponentImportVariants(value)
-    : getRegularImportVariants(value)
+    : getRegularImportVariants(value);
 
 module.exports = {
-meta: {
-  docs: {
-    description:
-      'disallow to use a different identifier than the module name.',
+  meta: {
+    docs: {
+      description:
+        'disallow to use a different identifier than the module name.',
+    },
   },
-},
 
-create(context) {
-  return {
-    ImportDeclaration(node) {
-      const [ specifier ] = node.specifiers;
-      if (!specifier) return;
+  create(context) {
+    return {
+      ImportDeclaration(node) {
+        const [ specifier ] = node.specifiers;
+        if (!specifier) return;
 
-      const { value } = node.source;
+        const { value } = node.source;
 
-      if (specifier.type !== 'ImportDefaultSpecifier') return;
-      if (!IMPORTS_WHITELIST.test(value)) return;
+        if (specifier.type !== 'ImportDefaultSpecifier') return;
+        if (!IMPORTS_WHITELIST.test(value)) return;
 
-      const importVariants = getImportVariants(value);
-      const { name } = specifier.local;
+        const importVariants = getImportVariants(value);
+        const { name } = specifier.local;
 
-      if (!importVariants.includes(name)) {
-        context.report({
-          node,
-          message:
-            `Default import "${name}" should be one of the following values: "${importVariants.join(', ')}".`,
-        });
+        if (!importVariants.includes(name)) {
+          context.report({
+            node,
+            message:
+              `Default import "${name}" should be one of the following values: "${importVariants.join(', ')}".`,
+          });
+        }
       }
     }
-  }
-},
+  },
 };

--- a/custom-rules/disallow-default-import-and-module-name-mismatch.js
+++ b/custom-rules/disallow-default-import-and-module-name-mismatch.js
@@ -15,8 +15,8 @@ const getComponentImportVariants = value =>
 
 const getImportVariants = value =>
   value.includes('components')
-    ? getRegularImportVariants(value)
-    : getComponentImportVariants(value)
+    ? getComponentImportVariants(value)
+    : getRegularImportVariants(value)
 
 module.exports = {
 meta: {
@@ -44,7 +44,7 @@ create(context) {
         context.report({
           node,
           message:
-            `Default import "${name}" should be on of the following values: "${importVariants.join(', ')}".`,
+            `Default import "${name}" should be one of the following values: "${importVariants.join(', ')}".`,
         });
       }
     }

--- a/test/custom-rules/disallow-default-import-and-module-name-mismatch.js
+++ b/test/custom-rules/disallow-default-import-and-module-name-mismatch.js
@@ -1,0 +1,38 @@
+'use strict';
+
+const rule = require('../../custom-rules/disallow-default-import-and-module-name-mismatch');
+const RuleTester = require('eslint').RuleTester;
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 2015,
+    sourceType: 'module',
+  }
+});
+
+const errors = [
+  {
+    message:
+      'Default import identifier should be the same as the module name.',
+  },
+];
+
+ruleTester.run('disallow-default-import-and-module-name-mismatch', rule, {
+  valid: [
+    { code: 'import Foo from "app/Foo";' },
+    { code: 'import Foo, { FooBar } from "app/Foo";' },
+    { code: 'import Foo from "bar/Baz";' },
+    { code: 'import { Foo, Bar } from "app/FooBar";' },
+  ],
+
+  invalid: [
+    {
+      code: 'import Foo from "app/Bar";',
+      errors,
+    },
+    {
+      code: 'import Foo, { Bar } from "app/Baz";',
+      errors,
+    },
+  ],
+});

--- a/test/custom-rules/disallow-default-import-and-module-name-mismatch.js
+++ b/test/custom-rules/disallow-default-import-and-module-name-mismatch.js
@@ -10,10 +10,10 @@ const ruleTester = new RuleTester({
   }
 });
 
-const errors = [
+const errors = (importName, moduleName) => [
   {
     message:
-      'Default import identifier should be the same as the module name.',
+      `Default import "${importName}" should be the same as the module name "${moduleName}".`
   },
 ];
 
@@ -28,11 +28,11 @@ ruleTester.run('disallow-default-import-and-module-name-mismatch', rule, {
   invalid: [
     {
       code: 'import Foo from "app/Bar";',
-      errors,
+      errors: errors('Foo', 'Bar'),
     },
     {
       code: 'import Foo, { Bar } from "app/Baz";',
-      errors,
+      errors: errors('Foo', 'Baz'),
     },
   ],
 });

--- a/test/custom-rules/disallow-default-import-and-module-name-mismatch.js
+++ b/test/custom-rules/disallow-default-import-and-module-name-mismatch.js
@@ -13,7 +13,7 @@ const ruleTester = new RuleTester({
 const errors = (importName, moduleName) => [
   {
     message:
-      `Default import "${importName}" should be the same as the module name "${moduleName}".`
+      `Default import "${importName}" should be the same as the module name "${moduleName}".`,
   },
 ];
 

--- a/test/custom-rules/disallow-default-import-and-module-name-mismatch.js
+++ b/test/custom-rules/disallow-default-import-and-module-name-mismatch.js
@@ -10,19 +10,20 @@ const ruleTester = new RuleTester({
   }
 });
 
-const errors = (importName, moduleName) => [
+const errors = (importName, importVariants) => [
   {
     message:
-      `Default import "${importName}" should be the same as the module name "${moduleName}".`,
+      `Default import "${importName}" should be one of the following values: "${importVariants}".`
   },
 ];
 
 ruleTester.run('disallow-default-import-and-module-name-mismatch', rule, {
   valid: [
-    { code: 'import Foo from "app/Foo";' },
-    { code: 'import Foo, { FooBar } from "app/Foo";' },
+    { code: 'import Foo from "app/module/Foo";' },
+    { code: 'import Foo, { FooBar } from "app/module/Foo";' },
     { code: 'import Foo from "bar/Baz";' },
-    { code: 'import { Foo, Bar } from "app/FooBar";' },
+    { code: 'import { Foo, Bar } from "app/module/FooBar";' },
+    { code: 'import FooBar from "app/module/components/Foo/Bar";' },
   ],
 
   invalid: [
@@ -33,6 +34,10 @@ ruleTester.run('disallow-default-import-and-module-name-mismatch', rule, {
     {
       code: 'import Foo, { Bar } from "app/Baz";',
       errors: errors('Foo', 'Baz'),
+    },
+    {
+      code: 'import Foo from "app/module/components/Foo/Bar";',
+      errors: errors('Foo', 'Bar, FooBar'),
     },
   ],
 });


### PR DESCRIPTION
Avoid specifying a default import than is different from a module name in the `app/` directory.

```js
// valid
import Foo from "app/Foo";
import Foo, { FooBar } from "app/Foo";
import Foo from "bar/Baz";
import { Foo, Bar } from "app/FooBar";
import FooBar from "app/module/components/Foo/Bar";

// invalid
import Foo from "app/Bar";
import Foo, { Bar } from "app/Baz";
```