### PR TITLE
Add flowtype rules that add flow globals

### DIFF
--- a/config/rules/flowtype.js
+++ b/config/rules/flowtype.js
@@ -1,11 +1,11 @@
 module.exports = {
-  'parser': 'babel-eslint',
+  parser: "babel-eslint",
 
-  'plugins': [
-    'flowtype',
-  ],
+  plugins: ["flowtype"],
 
-  'rules': {
-    'flowtype/no-types-missing-file-annotation': 'error',
-  },
+  rules: {
+    "flowtype/no-types-missing-file-annotation": "error",
+    "flowtype/define-flow-type": "error",
+    "flowtype/use-flow-type": "error"
+  }
 };


### PR DESCRIPTION
Instead of having to manually add some flow types as globals in consumer projects, add the `define-flow-type` and `use-flow-type` rules which automatically define all global flow types for us.