### PR TITLE
Added explicit booleans

### DIFF
--- a/config/rules/react.js
+++ b/config/rules/react.js
@@ -14,6 +14,7 @@ module.exports = {
     'react/jsx-no-undef': 'error',
     'react/jsx-uses-react': 'error',
     'react/jsx-uses-vars': 'error',
+    'react/jsx-boolean-value': ['error', 'always'],
     'react/react-in-jsx-scope': 'error',
   },
 };


### PR DESCRIPTION
[ISSUE](https://github.com/zapier/eslint-plugin-zapier/issues/35)

Added a new eslint rule to add `true` explicitly. 

So `<video controls={true}></video>` instead of `<video controls></video>` 

Why I agree to this: https://zapier.slack.com/archives/C0466L7SX/p1525438806000489?thread_ts=1525367986.000231&cid=C0466L7SX. 