### PR TITLE
[WIP] Add eslint-plugin-compat

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,7 +3,7 @@ const mapValues = require('lodash.mapvalues');
 const customRules = require('./config/rules/custom').rules;
 
 module.exports = {
-  extends: './config/prettier.js',
+  extends: './config/node.js',
   env: { node: true },
   rules: mapValues(customRules, () => 'off'),
 };

--- a/config/base.js
+++ b/config/base.js
@@ -5,6 +5,7 @@ module.exports = {
     './rules/react',
     './rules/jsx-a11y',
     './rules/flowtype',
+    './rules/compat',
   ].map(require.resolve),
 
   rules: {},

--- a/config/base.js
+++ b/config/base.js
@@ -5,8 +5,12 @@ module.exports = {
     './rules/react',
     './rules/jsx-a11y',
     './rules/flowtype',
-    './rules/compat',
-  ].map(require.resolve),
+  ]
+  .map(require.resolve)
+  .concat([
+    'prettier',
+    'prettier/react',
+  ]),
 
   rules: {},
 };

--- a/config/browser.js
+++ b/config/browser.js
@@ -2,8 +2,7 @@
 module.exports = {
   extends: [
     require.resolve('./base'),
-    'prettier',
-    'prettier/react',
+    require.resolve('./rules/compat'),
   ],
 
   rules: {},

--- a/config/browser.js
+++ b/config/browser.js
@@ -5,5 +5,9 @@ module.exports = {
     require.resolve('./rules/compat'),
   ],
 
+  env: {
+    browser: true,
+  },
+
   rules: {},
 };

--- a/config/node.js
+++ b/config/node.js
@@ -4,5 +4,9 @@ module.exports = {
     require.resolve('./base'),
   ],
 
+  env: {
+    node: true,
+  },
+
   rules: {},
 };

--- a/config/node.js
+++ b/config/node.js
@@ -1,0 +1,8 @@
+// prettier-ignore
+module.exports = {
+  extends: [
+    require.resolve('./base'),
+  ],
+
+  rules: {},
+};

--- a/config/rules/base.js
+++ b/config/rules/base.js
@@ -11,7 +11,6 @@ module.exports = {
 
   'env': {
     'commonjs': true,
-    'browser': true,
     'es6': true,
   },
 

--- a/config/rules/compat.js
+++ b/config/rules/compat.js
@@ -2,12 +2,12 @@ module.exports = {
   parser: 'babel-eslint',
 
   env: {
-    'browser': true
+    'browser': true,
   },
 
   plugins: ['compat'],
 
   rules: {
-    'compat/compat': 'error'
+    'compat/compat': 'error',
   }
 };

--- a/config/rules/compat.js
+++ b/config/rules/compat.js
@@ -1,0 +1,13 @@
+module.exports = {
+  parser: 'babel-eslint',
+
+  env: {
+    'browser': true
+  },
+
+  plugins: ['compat'],
+
+  rules: {
+    'compat/compat': 'error'
+  }
+};

--- a/config/rules/compat.js
+++ b/config/rules/compat.js
@@ -1,10 +1,4 @@
 module.exports = {
-  parser: 'babel-eslint',
-
-  env: {
-    'browser': true,
-  },
-
   plugins: ['compat'],
 
   rules: {

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ module.exports = {
   rules: requireIndex(path.join(__dirname, '/custom-rules')),
   configs: {
     base: require('./config/base'),
-    prettier: require('./config/prettier'),
+    node: require('./config/node'),
+    browser: require('./config/browser'),
   },
 };

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "babel-eslint": "^8.1.2",
     "eslint": "^4.14.0",
     "eslint-config-prettier": "2.6.0",
+    "eslint-plugin-compat": "^2.2.0",
     "eslint-plugin-flowtype": "2.35.0",
     "eslint-plugin-jsx-a11y": "6.0.2",
     "eslint-plugin-react": "7.3.0",
@@ -24,5 +25,9 @@
     "lodash.mapvalues": "^4.6.0",
     "mocha": "3.0.2",
     "prettier": "1.7.0"
-  }
+  },
+  "browserslist": [
+    "last 2 versions",
+    "IE 11"
+  ]
 }

--- a/test/config/tests.js
+++ b/test/config/tests.js
@@ -71,15 +71,22 @@ exports['eslint-plugin-zapier'] = {
     assert.doesNotThrow(() => linter.executeOnText(''));
   },
 
-  'exposes a prettier config': () => {
-    const linter = makeLinter('prettier');
+  'exposes a node config': () => {
+    const linter = makeLinter('node');
     const config = linter.getConfigForFile('foo.js');
 
     assert.ok(Object.keys(config.rules).length > 0);
   },
 
-  'prettier config contains base config': () => {
-    const config = makeLinter('prettier').getConfigForFile('foo.js');
+  'exposes a browser config': () => {
+    const linter = makeLinter('browser');
+    const config = linter.getConfigForFile('foo.js');
+
+    assert.ok(Object.keys(config.rules).length > 0);
+  },
+
+  'node config contains base config': () => {
+    const config = makeLinter('node').getConfigForFile('foo.js');
     const baseConfig = makeLinter('base').getConfigForFile('foo.js');
 
     assert.deepEqual(
@@ -88,21 +95,13 @@ exports['eslint-plugin-zapier'] = {
     );
   },
 
-  'prettier config turns a bunch of rules off': () => {
-    const config = makeLinter('prettier').getConfigForFile('./foo.js');
-    const baseConfig = makeLinter('base').getConfigForFile('./foo.js');
+  'browser config contains base config': () => {
+    const config = makeLinter('browser').getConfigForFile('foo.js');
+    const baseConfig = makeLinter('base').getConfigForFile('foo.js');
 
-    const getDisabledRules = rules =>
-      Object.keys(rules).reduce((acc, rule) => {
-        if (rules[rule] === 'off') {
-          return acc.concat(rule);
-        }
-        return acc;
-      }, []);
-
-    assert.ok(
-      getDisabledRules(config.rules).length >
-        getDisabledRules(baseConfig.rules).length
+    assert.deepEqual(
+      diff(Object.keys(baseConfig.rules), Object.keys(config.rules)),
+      []
     );
   },
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -187,6 +187,13 @@ babel-eslint@^8.1.2:
     eslint-scope "~3.7.1"
     eslint-visitor-keys "^1.0.0"
 
+babel-runtime@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
+  dependencies:
+    core-js "^2.4.0"
+    regenerator-runtime "^0.11.0"
+
 babylon@7.0.0-beta.40, babylon@^7.0.0-beta.40:
   version "7.0.0-beta.40"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-7.0.0-beta.40.tgz#91fc8cd56d5eb98b28e6fde41045f2957779940a"
@@ -206,6 +213,13 @@ browser-stdout@1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.0.tgz#f351d32969d32fa5d7a5567154263d928ae3bd1f"
 
+browserslist@^2.11.3:
+  version "2.11.3"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-2.11.3.tgz#fe36167aed1bbcde4827ebfe71347a2cc70b99b2"
+  dependencies:
+    caniuse-lite "^1.0.30000792"
+    electron-to-chromium "^1.3.30"
+
 caller-path@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/caller-path/-/caller-path-0.1.0.tgz#94085ef63581ecd3daa92444a8fe94e82577751f"
@@ -215,6 +229,14 @@ caller-path@^0.1.0:
 callsites@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-0.2.0.tgz#afab96262910a7f33c19a5775825c69f34e350ca"
+
+caniuse-db@^1.0.30000794:
+  version "1.0.30000839"
+  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000839.tgz#55a86e402c74ae17149707bea3ea399522233497"
+
+caniuse-lite@^1.0.30000792:
+  version "1.0.30000839"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000839.tgz#41fcc036cf1cb77a0e0be041210f77f1ced44a7b"
 
 chalk@^1.1.3:
   version "1.1.3"
@@ -292,6 +314,10 @@ core-js@^1.0.0:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
 
+core-js@^2.4.0:
+  version "2.5.6"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.6.tgz#0fe6d45bf3cac3ac364a9d72de7576f4eb221b9d"
+
 core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
@@ -353,6 +379,10 @@ doctrine@^2.0.0, doctrine@^2.1.0:
   dependencies:
     esutils "^2.0.2"
 
+electron-to-chromium@^1.3.30:
+  version "1.3.45"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.45.tgz#458ac1b1c5c760ce8811a16d2bfbd97ec30bafb8"
+
 emoji-regex@^6.1.0:
   version "6.5.1"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-6.5.1.tgz#9baea929b155565c11ea41c6626eaa65cef992c2"
@@ -390,6 +420,16 @@ eslint-config-prettier@2.6.0:
   resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-2.6.0.tgz#f21db0ebb438ad678fb98946097c4bb198befccc"
   dependencies:
     get-stdin "^5.0.1"
+
+eslint-plugin-compat@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-compat/-/eslint-plugin-compat-2.2.0.tgz#d612a9988d9fba66bcd8e86fcc1b551753aac995"
+  dependencies:
+    babel-runtime "^6.26.0"
+    browserslist "^2.11.3"
+    caniuse-db "^1.0.30000794"
+    mdn-browser-compat-data "^0.0.20"
+    requireindex "^1.1.0"
 
 eslint-plugin-flowtype@2.35.0:
   version "2.35.0"
@@ -501,6 +541,10 @@ estraverse@^4.0.0, estraverse@^4.1.0, estraverse@^4.1.1:
 esutils@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
+
+extend@3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.1.tgz#a755ea7bc1adfcc5a31ce7e762dbaadc5e636444"
 
 external-editor@^2.0.4:
   version "2.1.0"
@@ -874,6 +918,12 @@ lru-cache@^4.0.1:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
 
+mdn-browser-compat-data@^0.0.20:
+  version "0.0.20"
+  resolved "https://registry.yarnpkg.com/mdn-browser-compat-data/-/mdn-browser-compat-data-0.0.20.tgz#26e4a226d96cc5318fdc504d6dfd86907752da5c"
+  dependencies:
+    extend "3.0.1"
+
 mimic-fn@^1.0.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022"
@@ -1039,6 +1089,10 @@ readable-stream@^2.2.2:
     safe-buffer "~5.1.1"
     string_decoder "~1.0.3"
     util-deprecate "~1.0.1"
+
+regenerator-runtime@^0.11.0:
+  version "0.11.1"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
 
 require-uncached@^1.0.3:
   version "1.0.3"


### PR DESCRIPTION
This PR adds [eslint-plugin-compat](https://github.com/amilajack/eslint-plugin-compat).

As discussed in Slack @vitorbal, I've added a `browser` config and refactored the existing one (cf. commit messages).

I still need to test that with the `zapier` codebase to see if everything is fine. Meanwhile feel free to give me your feedback.