### PR TITLE
Add new custom rule to enforce async chunk names

### DIFF
--- a/config/rules/custom.js
+++ b/config/rules/custom.js
@@ -1,5 +1,6 @@
 module.exports = {
   rules: {
     '@zapier/zapier/disallow-lodash-get-dot-notation': 'error',
+    '@zapier/zapier/enforce-async-chunk-naming-scheme': 'error',
   },
 };

--- a/custom-rules/enforce-async-chunk-naming-scheme.js
+++ b/custom-rules/enforce-async-chunk-naming-scheme.js
@@ -1,0 +1,55 @@
+const getWebpackChunkNameFromNode = node => {
+  const { leadingComments = [], trailingComments = [] } = node;
+  const inlineComments = [...leadingComments, ...trailingComments];
+  const webpackChunkNameComment = inlineComments.find(comment =>
+    comment.value.includes("webpackChunkName")
+  );
+
+  if (!webpackChunkNameComment) {
+    return null;
+  }
+
+  const [, , chunkName] = webpackChunkNameComment.value.match(
+    /webpackChunkName:(\s+)?'(.*)'/
+  );
+
+  return chunkName;
+};
+
+module.exports = {
+  meta: {
+    docs: {
+      description:
+        "Enforce that webpack async chunk names always follow a pattern derived by the module path"
+    }
+  },
+
+  create(context) {
+    return {
+      // Example of a node we're looking for:
+      // import(/* webpackChunkName: 'team-route' */ 'app/team/asyncRoute')
+      Import(node) {
+        const callExpression = node.parent;
+        const argument = callExpression.arguments[0];
+        if (!argument) {
+          return;
+        }
+
+        const webpackChunkName = getWebpackChunkNameFromNode(argument);
+        if (!webpackChunkName) {
+          return;
+        }
+
+        // Replace `/` with `-`
+        const expectedChunkName = argument.value.replace(/\//g, "-");
+
+        if (webpackChunkName !== expectedChunkName) {
+          context.report({
+            node,
+            message: `Expected: ${expectedChunkName} Received: ${webpackChunkName}.`
+          });
+        }
+      }
+    };
+  }
+};

--- a/test/custom-rules/enforce-async-chunk-naming-scheme.js
+++ b/test/custom-rules/enforce-async-chunk-naming-scheme.js
@@ -1,0 +1,73 @@
+"use strict";
+
+const rule = require("../../custom-rules/enforce-async-chunk-naming-scheme");
+const RuleTester = require("eslint").RuleTester;
+
+const ruleTester = new RuleTester({
+  parser: "babel-eslint"
+});
+
+ruleTester.run("enforce-async-chunk-naming-scheme", rule, {
+  valid: [
+    {
+      code:
+        "import(/* webpackChunkName: 'app-team-asyncRoute' */ 'app/team/asyncRoute')"
+    },
+    {
+      code:
+        "import('app/team/asyncRoute'/* webpackChunkName: 'app-team-asyncRoute' */)"
+    }
+  ],
+
+  invalid: [
+    {
+      code:
+        "import(/* webpackChunkName: 'team-route' */ 'app/team/asyncRoute')",
+      errors: [
+        {
+          message: "Expected: app-team-asyncRoute Received: team-route.",
+          type: "Import"
+        }
+      ]
+    },
+    {
+      code:
+        "import('app/team/asyncRoute' /* webpackChunkName: 'team-route' */)",
+      errors: [
+        {
+          message: "Expected: app-team-asyncRoute Received: team-route.",
+          type: "Import"
+        }
+      ]
+    },
+    // With no spaces inside the webpackChunkName comment
+    {
+      code: "import(/*webpackChunkName:'team-route'*/ 'app/team/asyncRoute')",
+      errors: [
+        {
+          message: "Expected: app-team-asyncRoute Received: team-route.",
+          type: "Import"
+        }
+      ]
+    },
+    {
+      code: "import(/* webpackChunkName:'team-route' */ 'app/team/asyncRoute')",
+      errors: [
+        {
+          message: "Expected: app-team-asyncRoute Received: team-route.",
+          type: "Import"
+        }
+      ]
+    },
+    {
+      code:
+        "import(/* webpackChunkName:     'team-route' */ 'app/team/asyncRoute')",
+      errors: [
+        {
+          message: "Expected: app-team-asyncRoute Received: team-route.",
+          type: "Import"
+        }
+      ]
+    }
+  ]
+});


### PR DESCRIPTION
This adds a new rule to enforce a specific async chunk naming scheme:

```js
// Good
import(/* webpackChunkName: 'app-team-asyncRoute' */ 'app/team/asyncRoute')
import(/* webpackChunkName: 'app-onboarding-components-OnboardingModal' */ 'app/onboarding/components/OnboardingModal')

// Bad
import(/* webpackChunkName: 'team-route' */ 'app/team/asyncRoute')
import(/* webpackChunkName: 'onboarding-modal' */ 'app/onboarding/components/OnboardingModal')
```

## Why do we want to do this?
This prevents collisions between async chunks that might be hard to debug. It also makes it easy to tell which module is being async-loaded just by looking at the async chunk filename.

## TODO
- [ ] better error message
- [ ] enforce that async chunks should always have a custom name