### PR TITLE
[FE-98] Adds new recommended a11y rules

### DIFF
--- a/config/rules/jsx-a11y.js
+++ b/config/rules/jsx-a11y.js
@@ -1,3 +1,4 @@
+// recommended rules from https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/src/index.js
 module.exports = {
   'plugins': [
     'jsx-a11y',
@@ -6,8 +7,40 @@ module.exports = {
   'rules': {
     'jsx-a11y/alt-text': 'error',
     'jsx-a11y/aria-role': 'error',
-    'jsx-a11y/interactive-supports-focus': 'error',
-    'jsx-a11y/no-noninteractive-element-interactions': ['error',
+    'jsx-a11y/interactive-supports-focus': [
+      'error',
+      {
+        'tabbable': [
+          'button',
+          'checkbox',
+          'link',
+          'searchbox',
+          'spinbutton',
+          'switch',
+          'textbox'
+        ]
+      }
+    ],
+    'jsx-a11y/no-noninteractive-element-interactions': [
+      'error',
+      {
+        'handlers': [
+          'onClick',
+          'onError',
+          'onLoad',
+          'onMouseDown',
+          'onMouseUp',
+          'onKeyPress',
+          'onKeyDown',
+          'onKeyUp'
+        ],
+        'body': ['onError', 'onLoad'],
+        'iframe': ['onError', 'onLoad'],
+        'img': ['onError', 'onLoad']
+      }
+    ],
+    'jsx-a11y/no-static-element-interactions': [
+      'error',
       {
         'handlers': [
           'onClick',
@@ -15,10 +48,72 @@ module.exports = {
           'onMouseUp',
           'onKeyPress',
           'onKeyDown',
-          'onKeyUp',
-        ],
-      },
+          'onKeyUp'
+        ]
+      }
     ],
-    'jsx-a11y/no-static-element-interactions': 'error',
+    'jsx-a11y/accessible-emoji': 'warn',
+    'jsx-a11y/anchor-has-content': 'warn',
+    'jsx-a11y/anchor-is-valid': 'warn',
+    'jsx-a11y/aria-activedescendant-has-tabindex': 'warn',
+    'jsx-a11y/aria-props': 'warn',
+    'jsx-a11y/aria-proptypes': 'warn',
+    'jsx-a11y/aria-unsupported-elements': 'warn',
+    'jsx-a11y/click-events-have-key-events': 'warn',
+    'jsx-a11y/heading-has-content': 'warn',
+    'jsx-a11y/html-has-lang': 'warn',
+    'jsx-a11y/iframe-has-title': 'warn',
+    'jsx-a11y/img-redundant-alt': 'warn',
+    'jsx-a11y/label-has-for': 'warn',
+    'jsx-a11y/media-has-caption': 'warn',
+    'jsx-a11y/mouse-events-have-key-events': 'warn',
+    'jsx-a11y/no-access-key': 'warn',
+    'jsx-a11y/no-autofocus': 'warn',
+    'jsx-a11y/no-distracting-elements': 'warn',
+    'jsx-a11y/no-interactive-element-to-noninteractive-role': [
+      'warn',
+      {
+        'tr': ['none', 'presentation']
+      }
+    ],
+    'jsx-a11y/no-noninteractive-element-to-interactive-role': [
+      'warn',
+      {
+        'ul': [
+          'listbox',
+          'menu',
+          'menubar',
+          'radiogroup',
+          'tablist',
+          'tree',
+          'treegrid'
+        ],
+        'ol': [
+          'listbox',
+          'menu',
+          'menubar',
+          'radiogroup',
+          'tablist',
+          'tree',
+          'treegrid'
+        ],
+        'li': ['menuitem', 'option', 'row', 'tab', 'treeitem'],
+        'table': ['grid'],
+        'td': ['gridcell']
+      }
+    ],
+    'jsx-a11y/no-noninteractive-tabindex': [
+      'warn',
+      {
+        'tags': [],
+        'roles': ['tabpanel']
+      }
+    ],
+    'jsx-a11y/no-onchange': 'warn',
+    'jsx-a11y/no-redundant-roles': 'warn',
+    'jsx-a11y/role-has-required-aria-props': 'warn',
+    'jsx-a11y/role-supports-aria-props': 'warn',
+    'jsx-a11y/scope': 'warn',
+    'jsx-a11y/tabindex-no-positive': 'warn'
   },
 };


### PR DESCRIPTION
## Description

Adds new recommended a11y rules from https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/src/index.js

It does add a bit of noise (79 warnings currently). However, one advantage of having the warnings in the regular lint task is that people might get tired of seeing them and be more likely to fix them (out of sight out of mind).

![image](https://cl.ly/3t3d0O321a0y/Image%202018-06-12%20at%2010.39.28%20PM.png)


## Type of Changes
<!--- Put an `✓` for the applicable box: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :sparkles: New feature |

## Related Issue

React's [accessibility page](https://reactjs.org/docs/accessibility.html) recommends having both development assistance and audits in the browser console: https://github.com/zapier/zapier/pull/18085

https://zapierorg.atlassian.net/browse/FE-96

## Testing Instructions
 * `yarn link` this repo to `zapier/zapier` to test out the rules locally

	![image](https://user-images.githubusercontent.com/1666031/41327481-a8896f38-6e91-11e8-9581-2125ccc039f8.png)
 * Run `yarn lint` in `zapier/zapier`

