### PR TITLE
Switch to Travis CI VM infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
-sudo: false
-dist: trusty
 language: node_js
-cache:
-  directories:
-    - node_modules
-notifications:
-  email: false
 node_js:
   - 'stable'
   - 'lts/*'
+
+cache:
+  directories:
+    - node_modules
+
+notifications:
+  email: false

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Shareable recommended rule configuration and custom rules for internal Zapier usage.
 
+[![Build Status](https://travis-ci.org/zapier/eslint-plugin-zapier.svg?branch=master)](https://travis-ci.org/zapier/eslint-plugin-zapier)
+
 ## Installation
 
 ```


### PR DESCRIPTION
'sudo' is deprecated: https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration