### PR TITLE
Elinimating a warning of deprecation by upgrading ecmaVersion.

### DIFF
--- a/config/rules/base.js
+++ b/config/rules/base.js
@@ -2,11 +2,8 @@ module.exports = {
   'extends': 'eslint:recommended',
 
   'parserOptions': {
-    'ecmaVersion': 2017,
+    'ecmaVersion': 2018,
     'sourceType': 'module',
-    'ecmaFeatures': {
-      'experimentalObjectRestSpread': true,
-    },
   },
 
   'env': {


### PR DESCRIPTION
Below is where this fix resulted from

```
(node:75082) [ESLINT_LEGACY_OBJECT_REST_SPREAD] DeprecationWarning: The 'parserOptions.ecmaFeatures.experimentalObjectRestSpread' option
 is deprecated. Use 'parserOptions.ecmaVersion' instead. (found in "node_modules/@zapier/eslint-plugin-zapier/config/rules/base.js")
```