### PR TITLE
Add disallow-regexp-lookbehind assertion

### DIFF
--- a/config/rules/custom.js
+++ b/config/rules/custom.js
@@ -1,6 +1,7 @@
 module.exports = {
   rules: {
     "@zapier/zapier/disallow-lodash-get-dot-notation": "error",
+    '@zapier/zapier/disallow-regexp-lookbehind': 'error',
     "no-restricted-syntax": [
       "error",
       {

--- a/custom-rules/disallow-regexp-lookbehind.js
+++ b/custom-rules/disallow-regexp-lookbehind.js
@@ -1,0 +1,22 @@
+module.exports = {
+  meta: {
+    docs: {
+      description:
+        "disallow using lookbehind in regular expressions as they are not supported in FF / Safari",
+    },
+  },
+
+  create(context) {
+    return {
+      RegExpLiteral(node) {
+        if (node.pattern.includes('(?<!')) {
+          context.report({
+            node,
+            message:
+              'Lookbehind assertion found. Please do not use lookbehinds in RegExp as they are not widely supported.',
+          })
+        }
+      },
+    };
+  },
+};

--- a/test/custom-rules/disallow-regexp-lookbehind.js
+++ b/test/custom-rules/disallow-regexp-lookbehind.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const rule = require('../../custom-rules/disallow-regexp-lookbehind');
+const RuleTester = require('eslint').RuleTester;
+
+const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 2015 } });
+
+const errors = [
+  {
+    message:
+      'Lookbehind assertion found. Please do not use lookbehinds in RegExp as they are not widely supported.',
+  },
+];
+
+ruleTester.run('disallow-regexp-lookbehind', rule, {
+  valid: [
+    { code: 'const a = /.?<!/g' },
+  ],
+
+  invalid: [
+    {
+      code: 'const a = /(?<!https?:)/g',
+      errors,
+    },
+  ],
+});


### PR DESCRIPTION
Using the lookbehind assertion in a regexp caused an outage on FF/Safari because it's not yet supported in these browsers.

To avoid future errors, this PR adds an ESLint rule to make sure we don't use lookbehind assertions.

@vitorbal I think ESLint parser might be outdated. The new tests are failing because it seems ESLint can't parse a RegExp with a lookbehind assertion. After digging a little it seems that it's a `ES2018` addition. Our build system compiles it successfully so we might want to align ESLint parser to `ES2018`. However I'm not exactly sure on how to do that properly in this project.